### PR TITLE
set IDE distribution dependency to a fixed value, to avoid downloadin…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ sourceSets {
 }
 
 intellij {
-  version 'IC-LATEST-EAP-SNAPSHOT'
+  version 'IC-2019.1.2'
   pluginName 'markdown'
   downloadSources false
   updateSinceUntilBuild false


### PR DESCRIPTION
…g of latest snapshot over and over again.