### PR TITLE
perf: ensure actions are updated on EDT thread

### DIFF
--- a/src/org/intellij/plugins/markdown/ui/actions/editorLayout/BaseChangeSplitLayoutAction.java
+++ b/src/org/intellij/plugins/markdown/ui/actions/editorLayout/BaseChangeSplitLayoutAction.java
@@ -1,5 +1,6 @@
 package org.intellij.plugins.markdown.ui.actions.editorLayout;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Toggleable;
@@ -15,6 +16,12 @@ abstract class BaseChangeSplitLayoutAction extends AnAction implements DumbAware
 
   protected BaseChangeSplitLayoutAction(@Nullable SplitFileEditor.SplitEditorLayout layoutToSet) {
     myLayoutToSet = layoutToSet;
+  }
+
+  @Override
+  @NotNull
+  public ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.EDT;
   }
 
   @Override

--- a/src/org/intellij/plugins/markdown/ui/actions/editorLayout/ZenUmlEditorOnlyLayoutChangeAction.java
+++ b/src/org/intellij/plugins/markdown/ui/actions/editorLayout/ZenUmlEditorOnlyLayoutChangeAction.java
@@ -1,9 +1,17 @@
 package org.intellij.plugins.markdown.ui.actions.editorLayout;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import org.intellij.plugins.markdown.ui.split.SplitFileEditor;
+import org.jetbrains.annotations.NotNull;
 
 public class ZenUmlEditorOnlyLayoutChangeAction extends BaseChangeSplitLayoutAction {
   protected ZenUmlEditorOnlyLayoutChangeAction() {
     super(SplitFileEditor.SplitEditorLayout.FIRST);
+  }
+
+  @Override
+  @NotNull
+  public ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.EDT;
   }
 }

--- a/src/org/intellij/sequencer/ShowSequenceAction.java
+++ b/src/org/intellij/sequencer/ShowSequenceAction.java
@@ -1,5 +1,6 @@
 package org.intellij.sequencer;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -11,6 +12,7 @@ import org.intellij.sequencer.generator.filters.NoConstructorsFilter;
 import org.intellij.sequencer.generator.filters.NoGetterSetterFilter;
 import org.intellij.sequencer.generator.filters.NoPrivateMethodsFilter;
 import org.intellij.sequencer.generator.filters.ProjectOnlyFilter;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
@@ -22,6 +24,12 @@ public class ShowSequenceAction extends AnAction {
     private boolean _noPrivateMethods;
     private boolean _noConstructors;
     private boolean _smartInterface = true;
+
+    @Override
+    @NotNull
+    public ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
+    }
 
     public ShowSequenceAction() {
     }


### PR DESCRIPTION
- Update BaseChangeSplitLayoutAction, ZenUmlEditorOnlyLayoutChangeAction, and ShowSequenceAction to specify EDT thread for action updates
- Add getActionUpdateThread() method to each action class, returning ActionUpdateThread.EDT
- This change ensures that action updates are performed on the Event Dispatch Thread, improving performance and avoiding potential threading issues